### PR TITLE
image-gallery: make documentation example easier

### DIFF
--- a/content/en/add-ons/image-gallery.md
+++ b/content/en/add-ons/image-gallery.md
@@ -19,7 +19,7 @@ Step 2. Save the file in the ‘layouts/partials directory of your project
 Step 3. Add the following line to your layout on the place where you want the image gallery to appear:  
 
 ```
-{{ partial "image-gallery" (dict "context" . "gallery_dir" "album") }}
+{{ partial "image-gallery" (dict "context" . "gallery_dir" "/album") }}
 ```
 
 ### Shortcode installation
@@ -29,5 +29,5 @@ Step 2. Save the file in the ‘layouts/shortcodes directory of your project
 Step 3. Add the following line to your content on the place where you want the image gallery to appear:  
 
 ```
-{{</* image-gallery gallery_dir="album" */>}}
+{{</* image-gallery gallery_dir="/album" */>}}
 ```

--- a/content/es/add-ons/galeria-de-imagenes.md
+++ b/content/es/add-ons/galeria-de-imagenes.md
@@ -21,7 +21,7 @@ Paso 1. Descarga el fichero  [image-gallery.html](https://raw.githubusercontent.
 Paso 2. Guárdalo en el directorio 'layouts/partials'.  
 Paso 3. Añade la siguiente línea a tu plantilla en el lugar donde quieres que aparezca tu galería de imágenes: 
 ```
-{{ partial "image-gallery" (dict "context" . "gallery_dir" "album") }}
+{{ partial "image-gallery" (dict "context" . "gallery_dir" "/album") }}
 ```
 
 ### Instalación del shortcode 
@@ -31,5 +31,5 @@ Paso2. Guárdalo en el directorio 'layouts/shortcodes'.
 Paso3. Añade la siguiente línea  al fichero 'markdown' correspondiente a tu contenido, en el lugar donde quieres que aparezca tu galería de imágenes:  
 
 ```
-{{</* image-gallery gallery_dir="album" */>}}
+{{</* image-gallery gallery_dir="/album" */>}}
 ```


### PR DESCRIPTION
To use the image gallery, I copied and pasted from the [image-gallery documentation page](https://hugocodex.org/add-ons/image-gallery/), and put my pictures in `static/album`.
Then I got an error.

```
ERROR 2023/12/30 19:53:23 Rebuild failed: failed to render pages: render of "section" failed: "[]/layouts/section/gallery.html:61:7": execute of template failed at <partial "image-gallery" (dict "context" . "gallery_dir" "album")>: error calling partial: "[]/layouts/partials/image-gallery.html:11:10": execute of template failed at <readDir (print "/static" $dir)>: error calling readDir: failed to read directory "/staticalbum": open []/staticalbum: no such file or directory
```

I fixed the problem by adding a slash to the name of the directory.

```
{{ partial "image-gallery" (dict "context" . "gallery_dir" "/album") }}
```

This wasn't hard to solve, but I think having the leading slash in the documentation makes it easier to use.
